### PR TITLE
BUGFIX: Correct Iptc CreationDate extraction

### DIFF
--- a/Classes/Domain/Extractor/IptcIimExtractor.php
+++ b/Classes/Domain/Extractor/IptcIimExtractor.php
@@ -88,14 +88,12 @@ class IptcIimExtractor extends AbstractExtractor
         $iptcData['Instructions'] = $iim->getProperty(Iptc\Iim::SPECIAL_INSTRUCTIONS);
 
         $creationDateString = $iim->getProperty(Iptc\Iim::DATE_CREATED);
-        if (empty($creationDateString)) {
+        if (!empty($creationDateString)) {
             $creationTimeString = $iim->getProperty(Iptc\Iim::TIME_CREATED);
             $creationDateString .= empty($creationTimeString) ? '000000+0000' : $creationTimeString;
             $iptcData['CreationDate'] = \DateTime::createFromFormat('YmdHisO', $creationDateString);
-        } else {
-            $iptcData['CreationDate'] = \DateTime::createFromFormat('Ymd', $creationDateString);
         }
-        
+
         $iptcData['Creator'] = $iim->getProperty(Iptc\Iim::BYLINE);
         $iptcData['CreatorTitle'] = $iim->getProperty(Iptc\Iim::BYLINE_TITLE);
         $iptcData['City'] = $iim->getProperty(Iptc\Iim::CITY);

--- a/Readme.md
+++ b/Readme.md
@@ -3,12 +3,12 @@ This package handles extraction of meta data from assets.
 
 **Note: This package is work in progress. The class structure and interfaces may change a lot over time. The package is not meant for productive use.**
 
-The package provides the `ExtractorInterface`. Implementing classes provide the compatible media types and are called with the target assets. Returned DTOs are added to a collection and forwarded to the central `MetaDataManger` of package *Neos.MetaData*.
+The package provides the `ExtractorInterface`. With `isSuitableFor()` the implementing classes decide if they will be used for a specific resource. The `AbstractExtractor` implements a check by media type. Just extend and set `$compatibleMediaTypes` to the possible media type range(s). Returned DTOs are added to a collection and forwarded to the central `MetaDataManger` of the package *Neos.MetaData*.
 
-## Adapters
+## Extractors
 The `ExtractionManager` itself generates the `Asset` DTO for every valid Asset. 
 
-### `ExifExtacrtor` ([EXIF](http://www.exif.org/))
+### `ExifExtractor` ([EXIF](http://www.exif.org/))
 
 #### Supported Media Types
 * image/jpeg

--- a/Tests/Functional/Domain/Extractor/IptcIimExtractorTest.php
+++ b/Tests/Functional/Domain/Extractor/IptcIimExtractorTest.php
@@ -51,7 +51,7 @@ class IptcIimExtractorTest extends AbstractExtractorTest
             'CopyrightNotice' => '© Daniel Lienert',
             'Country' => 'Newzealand',
             'CountryCode' => 'NZ',
-            'CreationDate' => \DateTime::createFromFormat('Ymd', '20130918'),
+            'CreationDate' => \DateTime::createFromFormat('YmdHis', '20130918105911'),
             'Creator' => ['Daniel Lienert'],
             'CreatorTitle' => ['Informatiker'],
             'CreditLine' => 'by-nc',

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "type": "neos-package",
     "license": "MIT",
     "require": {
+        "ext-exif": "*",
         "neos/metadata": "*"
     },
     "autoload": {


### PR DESCRIPTION
Regression of 4547ed2.
Why would you even change the test to hide the bug?

I also marked `ext-exif` as required, since it is needed for the ExifExtractor.