### PR TITLE
BUGFIX: require ext-mbstring & use mb_convert_econding instead of utf8_encode

### DIFF
--- a/Classes/Specifications/Iptc/Iim.php
+++ b/Classes/Specifications/Iptc/Iim.php
@@ -1254,7 +1254,7 @@ class Iim
         if (!array_key_exists(self::CODED_CHARACTER_SET, $properties)) {
             array_walk_recursive($properties, function (&$element) {
                 if (is_string($element) && mb_detect_encoding($element, 'UTF-8', true) === false) {
-                    $element = utf8_encode($element);
+                    $element = mb_convert_encoding($element, 'UTF-8', 'ISO-8859-1');
                 }
             });
         }

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,8 @@
   "license": "MIT",
   "require": {
     "ext-exif": "*",
+    "ext-mbstring": "*",
+
     "neos/flow": "^4.0",
     "neos/media": "^3.0",
     "neos/metadata": "^2.0",


### PR DESCRIPTION
we were using functions of `ext-mbstring` anyway, so I declared the dependency and switched the usage of `utf8_encode()` to `mb_convert_encoding()` to not need `ext-xml`.