### PR TITLE
BUGFIX: Catch values not being arrays despite being standardized as such

### DIFF
--- a/Classes/Domain/Extractor/ExifExtractor.php
+++ b/Classes/Domain/Extractor/ExifExtractor.php
@@ -60,6 +60,7 @@ class ExifExtractor extends AbstractExtractor
         'UndefinedTag:0xA433' => 'LensMake',
         'UndefinedTag:0xA434' => 'LensModel',
         'UndefinedTag:0xA435' => 'LensSerialNumber',
+        'UndefinedTag:0xA500' => 'Gamma',
     ];
 
     /**
@@ -174,8 +175,15 @@ class ExifExtractor extends AbstractExtractor
 
         foreach (static::$rationalArrayProperties as $rationalArrayProperty) {
             if (isset($exifData[$rationalArrayProperty])) {
-                foreach ($exifData[$rationalArrayProperty] as $key => $value) {
-                    $exifData[$rationalArrayProperty][$key] = NumberConverter::convertRationalToFloat($value);
+                // Although defined as an array, some implementations only use one rational
+                if (\is_array($exifData[$rationalArrayProperty])) {
+                    foreach ($exifData[$rationalArrayProperty] as $key => $value) {
+                        $exifData[$rationalArrayProperty][$key] = NumberConverter::convertRationalToFloat($value);
+                    }
+                } else {
+                    $exifData[$rationalArrayProperty] = NumberConverter::convertRationalToFloat(
+                        $exifData[$rationalArrayProperty]
+                    );
                 }
             }
         }


### PR DESCRIPTION
I had an image which stated `PrimaryChromaticities` as a single rational, despite it being defined as 6 of them.

With this patch, every such property won't throw an exception.