### PR TITLE
Delete metaData node independent of realtimeExtraction setting

### DIFF
--- a/Classes/Domain/ExtractionManager.php
+++ b/Classes/Domain/ExtractionManager.php
@@ -140,4 +140,31 @@ class ExtractionManager
 
         return $metaDataCollection;
     }
+
+    /**
+     * @param Asset $asset
+     * @return MetaDataCollection
+     * @throws ExtractorException
+     * @throws UnknownObjectException
+     */
+    public function onAssetRemoved(Asset $asset) : MetaDataCollection
+    {
+        if ($asset instanceof ImageVariant) {
+            $asset = $asset->getOriginalAsset();
+        }
+
+        $flowResource = $asset->getResource();
+        if ($flowResource === null) {
+            throw new ExtractorException('Resource of Asset "' . $asset->getTitle() . '"" not found.', 1484060541);
+        }
+
+        $metaDataCollection = new MetaDataCollection();
+        $this->buildAssetMetaData($asset, $metaDataCollection);
+
+        // Because the signal assetRemoved was emitted the deleted flag for $flowResource is true
+        // thus the signal metaDataCollectionUpdated finally deletes the metadata for the asset
+        $this->metaDataManager->emitMetaDataCollectionUpdated($asset, $metaDataCollection);
+
+        return $metaDataCollection;
+    }
 }

--- a/Classes/Domain/ExtractionManager.php
+++ b/Classes/Domain/ExtractionManager.php
@@ -161,10 +161,6 @@ class ExtractionManager
         $metaDataCollection = new MetaDataCollection();
         $this->buildAssetMetaData($asset, $metaDataCollection);
 
-        // Because the signal assetRemoved was emitted the deleted flag for $flowResource is true
-        // thus the signal metaDataCollectionUpdated finally deletes the metadata for the asset
-        $this->metaDataManager->emitMetaDataCollectionUpdated($asset, $metaDataCollection);
-
-        return $metaDataCollection;
+        $this->metaDataManager->updateMetaDataForAsset($asset, $metaDataCollection);
     }
 }

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -29,6 +29,8 @@ class Package extends BasePackage
     public function boot(Bootstrap $bootstrap)
     {
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
+        $dispatcher->connect(AssetService::class, 'assetRemoved', ExtractionManager::class, 'onAssetRemoved');
+
         $packageKey = $this->getPackageKey();
         $dispatcher->connect(
             ConfigurationManager::class,
@@ -51,6 +53,5 @@ class Package extends BasePackage
     {
         $dispatcher->connect(AssetService::class, 'assetCreated', ExtractionManager::class, 'extractMetaData');
         $dispatcher->connect(AssetService::class, 'assetUpdated', ExtractionManager::class, 'extractMetaData');
-        $dispatcher->connect(AssetService::class, 'assetRemoved', ExtractionManager::class, 'extractMetaData');
     }
 }


### PR DESCRIPTION
If one set's `Neos.MetaData.Extractor.realtimeExtraction.enabled` to false in Settings.yaml, the signal `assetRemoved` is not handled. Thus the nodedata table still contains nodes which have properties where the metadata entry is linked to a resource which does not exist any more, e.g. from properties of such a `Neos.MetaData:Image` node
```
{
    "assetObject": {
        "__flow_object_type": "Neos\\Media\\Domain\\Model\\Image",
        "__identifier": "033f5153-9089-467b-be6c-55735c69c19b"
    }
    ....
```
So, this patch is about preventing possible inconsistencies in the nodedata table.

This commit, always handles the signal `assetRemoved` using `ExtractionManager::onAssetRemoved` which signals `MetaDataCollectionUpdated` via `Neos\MetaData\MetaDataManager`. Thus the asset's metadata node is removed and rebuilding the metadata is also prevented by using `onAssetRemoved`.