### PR TITLE
BUGFIX: Fix leading zeros missing in DateConverter

### DIFF
--- a/Classes/Converter/DateConverter.php
+++ b/Classes/Converter/DateConverter.php
@@ -24,7 +24,7 @@ class DateConverter
     {
         return \DateTime::createFromFormat(
             'Y:m:d H:i:s',
-            $gpsDateStamp . ' ' . (int)$gpsTimeStamp[0] . ':' . (int)$gpsTimeStamp[1] . ':' . (int)$gpsTimeStamp[2]
+            $gpsDateStamp . ' ' . sprintf('%02d:%02d:%02d', (int)$gpsTimeStamp[0], (int)$gpsTimeStamp[1], (int)$gpsTimeStamp[2])
         );
     }
 

--- a/Classes/Converter/DateConverter.php
+++ b/Classes/Converter/DateConverter.php
@@ -24,7 +24,7 @@ class DateConverter
     {
         return \DateTime::createFromFormat(
             'Y:m:d H:i:s',
-            $gpsDateStamp . ' ' . sprintf('%02d:%02d:%02d', (int)$gpsTimeStamp[0], (int)$gpsTimeStamp[1], (int)$gpsTimeStamp[2])
+            $gpsDateStamp . ' ' . \sprintf('%02d:%02d:%02d', (int)$gpsTimeStamp[0], (int)$gpsTimeStamp[1], (int)$gpsTimeStamp[2])
         );
     }
 


### PR DESCRIPTION
The method `DateConvert::convertGpsDateAndTime` fails with an php error in case the values of hour/minute/seconds from `$gpsTimeStamp` are less than `10`. The reason is, that the format `H:i:s` assumes the values to have leading zeros, but for example `(int)$gpsTimeStamp[1]` can never have leading zeros.

Since the method has a type hint `: \DateTime` for the return value and DateTime cannot be created, the `\DateTime::createFromFormat` method returns false and thus the script is aborted due to a php error.