### PR TITLE
Fix unlink temporary files

### DIFF
--- a/Classes/Domain/Extractor/ExifExtractor.php
+++ b/Classes/Domain/Extractor/ExifExtractor.php
@@ -151,15 +151,19 @@ class ExifExtractor extends AbstractExtractor
      */
     public function extractMetaData(FlowResource $resource, MetaDataCollection $metaDataCollection)
     {
+        $temporaryLocalCopyPath = $resource->createTemporaryLocalCopy();
         try {
-            $exifData = @\exif_read_data($resource->createTemporaryLocalCopy(), 'EXIF');
+            $exifData = @\exif_read_data($temporaryLocalCopyPath, 'EXIF');
         } catch (FlowResourceException $exception) {
             throw new ExtractorException(
                 'Could not extract EXIF data from ' . $resource->getFilename(),
                 1484059228,
                 $exception
             );
+        } finally {
+            unlink($temporaryLocalCopyPath);
         }
+
         if ($exifData === false) {
             throw new ExtractorException('Could not extract EXIF data from ' . $resource->getFilename(), 1484056779);
         }

--- a/Classes/Domain/Extractor/ExifExtractor.php
+++ b/Classes/Domain/Extractor/ExifExtractor.php
@@ -151,18 +151,19 @@ class ExifExtractor extends AbstractExtractor
      */
     public function extractMetaData(FlowResource $resource, MetaDataCollection $metaDataCollection)
     {
-        $temporaryLocalCopyPath = $resource->createTemporaryLocalCopy();
         try {
-            $exifData = @\exif_read_data($temporaryLocalCopyPath, 'EXIF');
+            $temporaryLocalCopyPath = $resource->createTemporaryLocalCopy();
         } catch (FlowResourceException $exception) {
             throw new ExtractorException(
                 'Could not extract EXIF data from ' . $resource->getFilename(),
                 1484059228,
                 $exception
             );
-        } finally {
-            unlink($temporaryLocalCopyPath);
         }
+
+        $exifData = @\exif_read_data($temporaryLocalCopyPath, 'EXIF');
+
+        unlink($temporaryLocalCopyPath);
 
         if ($exifData === false) {
             throw new ExtractorException('Could not extract EXIF data from ' . $resource->getFilename(), 1484056779);

--- a/Classes/Domain/Extractor/ExifExtractor.php
+++ b/Classes/Domain/Extractor/ExifExtractor.php
@@ -163,7 +163,7 @@ class ExifExtractor extends AbstractExtractor
 
         $exifData = @\exif_read_data($temporaryLocalCopyPath, 'EXIF');
 
-        unlink($temporaryLocalCopyPath);
+        \unlink($temporaryLocalCopyPath);
 
         if ($exifData === false) {
             throw new ExtractorException('Could not extract EXIF data from ' . $resource->getFilename(), 1484056779);

--- a/Classes/Domain/Extractor/IptcIimExtractor.php
+++ b/Classes/Domain/Extractor/IptcIimExtractor.php
@@ -91,18 +91,19 @@ class IptcIimExtractor extends AbstractExtractor
      */
     public function extractMetaData(FlowResource $resource, MetaDataCollection $metaDataCollection)
     {
-        $temporaryLocalCopyPath = $resource->createTemporaryLocalCopy();
         try {
-            \getimagesize($temporaryLocalCopyPath, $fileInfo);
+            $temporaryLocalCopyPath = $resource->createTemporaryLocalCopy();
         } catch (FlowResourceException $exception) {
             throw new ExtractorException(
                 'Could not extract IPTC data from ' . $resource->getFilename(),
                 1484059892,
                 $exception
             );
-        } finally {
-            unlink($temporaryLocalCopyPath);
         }
+
+        \getimagesize($temporaryLocalCopyPath, $fileInfo);
+
+        unlink($temporaryLocalCopyPath);
 
         if (!isset($fileInfo['APP13'])) {
             throw new ExtractorException(

--- a/Classes/Domain/Extractor/IptcIimExtractor.php
+++ b/Classes/Domain/Extractor/IptcIimExtractor.php
@@ -91,15 +91,19 @@ class IptcIimExtractor extends AbstractExtractor
      */
     public function extractMetaData(FlowResource $resource, MetaDataCollection $metaDataCollection)
     {
+        $temporaryLocalCopyPath = $resource->createTemporaryLocalCopy();
         try {
-            \getimagesize($resource->createTemporaryLocalCopy(), $fileInfo);
+            \getimagesize($temporaryLocalCopyPath, $fileInfo);
         } catch (FlowResourceException $exception) {
             throw new ExtractorException(
                 'Could not extract IPTC data from ' . $resource->getFilename(),
                 1484059892,
                 $exception
             );
+        } finally {
+            unlink($temporaryLocalCopyPath);
         }
+
         if (!isset($fileInfo['APP13'])) {
             throw new ExtractorException(
                 'Could not find "APP13" section in file info of ' . $resource->getFilename(),

--- a/Classes/Domain/Extractor/IptcIimExtractor.php
+++ b/Classes/Domain/Extractor/IptcIimExtractor.php
@@ -103,7 +103,7 @@ class IptcIimExtractor extends AbstractExtractor
 
         \getimagesize($temporaryLocalCopyPath, $fileInfo);
 
-        unlink($temporaryLocalCopyPath);
+        \unlink($temporaryLocalCopyPath);
 
         if (!isset($fileInfo['APP13'])) {
             throw new ExtractorException(


### PR DESCRIPTION
Metadata extraction creates temporary files which fill up the disk. The files can be removed directly after metadata extraction via `exif_read_data` or `getimagesize`.