### PR TITLE
BUGFIX: Check for getCopyrightNotice() method before use

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -22,7 +22,6 @@ enabled:
   - modernize_types_casting
   - multiline_comment_opening_closing
   - native_function_casing
-  - native_function_invocation
   - newline_before_semicolons_chained
   - no_alias_functions
   - no_alternative_syntax

--- a/Classes/Domain/ExtractionManager.php
+++ b/Classes/Domain/ExtractionManager.php
@@ -78,7 +78,7 @@ class ExtractionManager
             'AssetObject' => $asset,
         ];
         if (method_exists($asset, 'getCopyrightNotice')) {
-            $properties['CopyrightNotice'] =  $asset->getCopyrightNotice();
+            $properties['CopyrightNotice'] = $asset->getCopyrightNotice();
         }
         $assetDto = new Dto\Asset($properties);
         $metaDataCollection->set('asset', $assetDto);

--- a/Classes/Domain/ExtractionManager.php
+++ b/Classes/Domain/ExtractionManager.php
@@ -68,16 +68,19 @@ class ExtractionManager
             $collections[] = $collectionObject->getTitle();
         }
 
-        $assetDto = new Dto\Asset([
+        $properties = [
             'Caption' => $asset->getCaption(),
-            'CopyrightNotice' => $asset->getCopyrightNotice(),
             'Identifier' => $asset->getIdentifier(),
             'Title' => $asset->getTitle(),
             'FileName' => $asset->getResource()->getFilename(),
             'Collections' => $collections,
             'Tags' => $tags,
             'AssetObject' => $asset,
-        ]);
+        ];
+        if (method_exists($asset, 'getCopyrightNotice')) {
+            $properties['CopyrightNotice'] =  $asset->getCopyrightNotice();
+        }
+        $assetDto = new Dto\Asset($properties);
         $metaDataCollection->set('asset', $assetDto);
     }
 


### PR DESCRIPTION
On Neos older than 4.2 the `Asset` has no `getCopyrightNotice()`,
but since this package claims compatibility, it needs to check before
calling it.

Fixes #26